### PR TITLE
Update to support webpack v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(content) {
     }
 
     id = matches.length ? matches[1] : id;
-    twig({ id: id, data: content }).compile({ module: 'node' });
+    tpl = twig({ id: id, data: content }).compile({ module: 'node' });
 
     return 'module.exports = ' + tpl.match(/(?:twig\()(.*)(?:\))/m)[1] + ';';
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-var utils = require("loader-utils"),
-    Twig = require('twig');
+var Twig = require('twig');
 
 module.exports = function(content) {
     var id = this.resource, matches, template, compiled, query, isCacheEnabled = false;
@@ -39,4 +38,4 @@ module.exports = function(content) {
 
     compiled = template.compile({ module: 'node' });
     return 'module.exports = ' + compiled.match(/(?:twig\()(.*)(?:\))/m)[1] + ';';
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,14 +1,23 @@
 var utils = require("loader-utils"),
-
-	twig = require('twig').twig;
+    twig = require('twig').twig;
 
 module.exports = function(content) {
+    var id = this.resource, matches, tpl;
 
-	var id = this.resource;
+    this.cacheable();
 
-	var tpl = twig({ id: id, data: content })
-		.compile({ module: 'node' });
+    if (!id) {
+        throw new Error('File name cannot be empty.');
+    }
 
-	return 'module.exports = ' + tpl.match(/(?:twig\()(.*)(?:\))/m)[1] + ';';
+    matches = id.match(/([^/\?#]+).*$/);
 
+    if (matches === null) {
+        throw new Error('File name is not valid "' + id + '"');
+    }
+
+    id = matches.length ? matches[1] : id;
+    twig({ id: id, data: content }).compile({ module: 'node' });
+
+    return 'module.exports = ' + tpl.match(/(?:twig\()(.*)(?:\))/m)[1] + ';';
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function(content) {
         throw new Error('File name cannot be empty.');
     }
 
-    matches = id.match(/([^/\?#]+).*$/);
+    matches = id.match(/([^\/]+$)/);
 
     if (matches === null) {
         throw new Error('File name is not valid "' + id + '"');

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var utils = require("loader-utils"),
     twig = require('twig').twig;
 
 module.exports = function(content) {
-    var id = this.resource, matches, tpl;
+    var id = this.resource, matches, template, compiled;
 
     this.cacheable();
 
@@ -17,7 +17,13 @@ module.exports = function(content) {
     }
 
     id = matches.length ? matches[1] : id;
-    tpl = twig({ id: id, data: content }).compile({ module: 'node' });
 
-    return 'module.exports = ' + tpl.match(/(?:twig\()(.*)(?:\))/m)[1] + ';';
+    // Checking for cached template
+    template = twig({ ref: id });
+    if (template === null) {
+        template = twig({ id: id, data: content });
+    }
+
+    compiled = template.compile({ module: 'node' });
+    return 'module.exports = ' + compiled.match(/(?:twig\()(.*)(?:\))/m)[1] + ';';
 }

--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ module.exports = function(content) {
     }
 
     // Checking for cached template
-    template = Twig.twig({ ref: id });
+    template = Twig.twig({ ref: id, rethrow: true });
     if (template === null) {
-        template = Twig.twig({ id: id, data: content });
+        template = Twig.twig({ id: id, data: content, rethrow: true });
     }
 
     // Removing the template from cache

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
   "dependencies": {
     "loader-utils": "^0.2.4",
     "twig": "^0.7.2"
-  }
+  },
+  "repository": "ecentria/webpack-twig-loader"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "license": "MIT",
 
   "dependencies": {
-    "loader-utils": "^0.2.4",
-    "twig": "^0.8"
+    "twig": "*"
   },
   "repository": "ecentria/webpack-twig-loader"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "loader-utils": "^0.2.4",
-    "twig": "^0.7.2"
+    "twig": "0.8.2"
   },
   "repository": "ecentria/webpack-twig-loader"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-twig-loader",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A twig.js loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "loader",
     "webpack-loader"
   ],
-  "author": "Emil Nordh <me@emilnordh.se>",
-  "license": "ISC",
+  "author": "Artem Petrov <artem.petrov@opticsplanet.com>",
+  "license": "MIT",
+
   "dependencies": {
     "loader-utils": "^0.2.4",
-    "twig": "0.8.2"
+    "twig": "^0.8"
   },
   "repository": "ecentria/webpack-twig-loader"
 }


### PR DESCRIPTION
Queries passed by webpack v2 no longer have a trailing '?' at the beginning of the query. An update is needed to support both webpack v1 and v2.